### PR TITLE
feat(auth): add support for Claude Code settings.json auth tokens

### DIFF
--- a/claude-rust-auth/src/application/resolve_credential.rs
+++ b/claude-rust-auth/src/application/resolve_credential.rs
@@ -1,7 +1,7 @@
 use claude_rust_errors::{AppError, AppResult};
 
 use crate::domain::Credential;
-use crate::infrastructure::{resolve_file_oauth, resolve_keychain_oauth};
+use crate::infrastructure::{resolve_file_oauth, resolve_keychain_oauth, resolve_settings_json};
 
 pub fn resolve_credential() -> AppResult<Credential> {
     if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
@@ -29,6 +29,16 @@ pub fn resolve_credential() -> AppResult<Credential> {
         }
         Err(e) => {
             tracing::debug!("file OAuth not available: {e}");
+        }
+    }
+
+    match resolve_settings_json() {
+        Ok(cred) => {
+            tracing::info!("using Claude Code auth from settings.json");
+            return Ok(cred);
+        }
+        Err(e) => {
+            tracing::debug!("settings.json not available: {e}");
         }
     }
 

--- a/claude-rust-auth/src/application/resolve_credential.rs
+++ b/claude-rust-auth/src/application/resolve_credential.rs
@@ -51,7 +51,7 @@ pub fn resolve_credential() -> AppResult<Credential> {
     }
 
     Err(AppError::Provider(
-        "no credentials found. Set ANTHROPIC_API_KEY, OPENROUTER_API_KEY, or log in with `claude`"
+        "no credentials found. Set ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN (from settings.json), OPENROUTER_API_KEY, or log in with `claude`"
             .to_string(),
     ))
 }

--- a/claude-rust-auth/src/domain/credential.rs
+++ b/claude-rust-auth/src/domain/credential.rs
@@ -48,6 +48,9 @@ impl Credential {
     }
 
     pub fn is_oauth(&self) -> bool {
-        matches!(self, Credential::ClaudeCodeOAuth { .. })
+        matches!(
+            self,
+            Credential::ClaudeCodeOAuth { .. } | Credential::AuthToken { .. }
+        )
     }
 }

--- a/claude-rust-auth/src/domain/credential.rs
+++ b/claude-rust-auth/src/domain/credential.rs
@@ -6,6 +6,10 @@ pub enum Credential {
         api_key: String,
         base_url: String,
     },
+    AuthToken {
+        token: String,
+        base_url: String,
+    },
     ClaudeCodeOAuth {
         access_token: String,
         expires_at: u64,
@@ -18,6 +22,11 @@ impl fmt::Debug for Credential {
             Credential::ApiKey { base_url, .. } => f
                 .debug_struct("ApiKey")
                 .field("api_key", &"[redacted]")
+                .field("base_url", base_url)
+                .finish(),
+            Credential::AuthToken { base_url, .. } => f
+                .debug_struct("AuthToken")
+                .field("token", &"[redacted]")
                 .field("base_url", base_url)
                 .finish(),
             Credential::ClaudeCodeOAuth { expires_at, .. } => f
@@ -33,6 +42,7 @@ impl Credential {
     pub fn base_url(&self) -> &str {
         match self {
             Credential::ApiKey { base_url, .. } => base_url,
+            Credential::AuthToken { base_url, .. } => base_url,
             Credential::ClaudeCodeOAuth { .. } => "https://api.anthropic.com",
         }
     }

--- a/claude-rust-auth/src/infrastructure/file_provider.rs
+++ b/claude-rust-auth/src/infrastructure/file_provider.rs
@@ -13,12 +13,8 @@ pub fn resolve_file_oauth() -> AppResult<Credential> {
         .join(".claude")
         .join(".credentials.json");
 
-    let contents = std::fs::read_to_string(&path).map_err(|e| {
-        AppError::Provider(format!(
-            "cannot read {}: {e}",
-            path.display()
-        ))
-    })?;
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| AppError::Provider(format!("cannot read {}: {e}", path.display())))?;
 
     let parsed: serde_json::Value = serde_json::from_str(&contents)
         .map_err(|e| AppError::Provider(format!("failed to parse credentials JSON: {e}")))?;
@@ -33,10 +29,7 @@ pub fn resolve_file_oauth() -> AppResult<Credential> {
         .ok_or_else(|| AppError::Provider("no accessToken in OAuth data".to_string()))?
         .to_string();
 
-    let expires_at = oauth
-        .get("expiresAt")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+    let expires_at = oauth.get("expiresAt").and_then(|v| v.as_u64()).unwrap_or(0);
 
     if expires_at > 0 {
         let now_ms = std::time::SystemTime::now()
@@ -56,4 +49,45 @@ pub fn resolve_file_oauth() -> AppResult<Credential> {
         access_token,
         expires_at,
     })
+}
+
+/// Reads auth token from `~/.claude/settings.json`, which is where Claude Code CLI stores
+/// environment variables including ANTHROPIC_AUTH_TOKEN and ANTHROPIC_BASE_URL.
+pub fn resolve_settings_json() -> AppResult<Credential> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| AppError::Provider("cannot determine home directory".to_string()))?;
+
+    let path = std::path::PathBuf::from(home)
+        .join(".claude")
+        .join("settings.json");
+
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| AppError::Provider(format!("cannot read {}: {e}", path.display())))?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&contents)
+        .map_err(|e| AppError::Provider(format!("failed to parse settings.json: {e}")))?;
+
+    let env = parsed
+        .get("env")
+        .ok_or_else(|| AppError::Provider("no env in settings.json".to_string()))?;
+
+    let token = env
+        .get("ANTHROPIC_AUTH_TOKEN")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::Provider("no ANTHROPIC_AUTH_TOKEN in settings.json".to_string()))?
+        .to_string();
+
+    let base_url = env
+        .get("ANTHROPIC_BASE_URL")
+        .and_then(|v| v.as_str())
+        .unwrap_or("https://api.anthropic.com")
+        .to_string();
+
+    tracing::info!(
+        "using ANTHROPIC_AUTH_TOKEN from settings.json, base_url: {}",
+        base_url
+    );
+
+    Ok(Credential::AuthToken { token, base_url })
 }

--- a/claude-rust-auth/src/infrastructure/file_provider.rs
+++ b/claude-rust-auth/src/infrastructure/file_provider.rs
@@ -81,13 +81,12 @@ pub fn resolve_settings_json() -> AppResult<Credential> {
     let base_url = env
         .get("ANTHROPIC_BASE_URL")
         .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
         .unwrap_or("https://api.anthropic.com")
         .to_string();
 
-    tracing::info!(
-        "using ANTHROPIC_AUTH_TOKEN from settings.json, base_url: {}",
-        base_url
-    );
+    tracing::debug!("using ANTHROPIC_AUTH_TOKEN from settings.json");
 
     Ok(Credential::AuthToken { token, base_url })
 }

--- a/claude-rust-auth/src/infrastructure/mod.rs
+++ b/claude-rust-auth/src/infrastructure/mod.rs
@@ -3,4 +3,4 @@ mod file_provider;
 pub mod oauth;
 
 pub use keychain_provider::resolve_keychain_oauth;
-pub use file_provider::resolve_file_oauth;
+pub use file_provider::{resolve_file_oauth, resolve_settings_json};

--- a/claude-rust-provider/src/infrastructure/anthropic_provider.rs
+++ b/claude-rust-provider/src/infrastructure/anthropic_provider.rs
@@ -165,27 +165,13 @@ impl Provider for AnthropicProvider {
         let body = build_request_body(&self.credential, &model_display, conversation, tools, thinking, max_tokens);
 
         let request = match &self.credential {
-            Credential::ClaudeCodeOAuth { access_token, .. } => {
+            Credential::ClaudeCodeOAuth { access_token, .. } | Credential::AuthToken { token: access_token, .. } => {
                 let url = format!("{base_url}/v1/messages?beta=true");
                 tracing::debug!(model = %model_display, url = %url, "sending OAuth request");
 
                 self.client
                     .post(&url)
                     .header("Authorization", format!("Bearer {access_token}"))
-                    .header("anthropic-version", "2023-06-01")
-                    .header("anthropic-beta", OAUTH_BETA_HEADER)
-                    .header("anthropic-dangerous-direct-browser-access", "true")
-                    .header("User-Agent", "claude-cli/2.1.87 (external, cli)")
-                    .header("x-app", "cli")
-                    .header("content-type", "application/json")
-            }
-            Credential::AuthToken { token, .. } => {
-                let url = format!("{base_url}/v1/messages?beta=true");
-                tracing::debug!(model = %model_display, url = %url, "sending AuthToken request");
-
-                self.client
-                    .post(&url)
-                    .header("Authorization", format!("Bearer {token}"))
                     .header("anthropic-version", "2023-06-01")
                     .header("anthropic-beta", OAUTH_BETA_HEADER)
                     .header("anthropic-dangerous-direct-browser-access", "true")

--- a/claude-rust-provider/src/infrastructure/anthropic_provider.rs
+++ b/claude-rust-provider/src/infrastructure/anthropic_provider.rs
@@ -179,6 +179,20 @@ impl Provider for AnthropicProvider {
                     .header("x-app", "cli")
                     .header("content-type", "application/json")
             }
+            Credential::AuthToken { token, .. } => {
+                let url = format!("{base_url}/v1/messages?beta=true");
+                tracing::debug!(model = %model_display, url = %url, "sending AuthToken request");
+
+                self.client
+                    .post(&url)
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("anthropic-version", "2023-06-01")
+                    .header("anthropic-beta", OAUTH_BETA_HEADER)
+                    .header("anthropic-dangerous-direct-browser-access", "true")
+                    .header("User-Agent", "claude-cli/2.1.87 (external, cli)")
+                    .header("x-app", "cli")
+                    .header("content-type", "application/json")
+            }
             Credential::ApiKey { api_key, .. } => {
                 let url = format!("{base_url}/v1/messages");
                 tracing::debug!(model = %model_display, url = %url, "sending API key request");


### PR DESCRIPTION
- Add Credential::AuthToken variant for ANTHROPIC_AUTH_TOKEN
- Add resolve_settings_json() to read from ~/.claude/settings.json
- Update credential resolution chain to check settings.json
- Update AnthropicProvider to handle AuthToken credentials

@maulanasdqn izin bang