### PR TITLE
feat: implement effort level support with adaptive thinking

### DIFF
--- a/claude-rust-commands/src/tests/parse_command_test.rs
+++ b/claude-rust-commands/src/tests/parse_command_test.rs
@@ -38,3 +38,27 @@ fn parse_unknown() {
     assert!(parse_command("/unknown").is_none());
     assert!(parse_command("hello").is_none());
 }
+
+#[test]
+fn parse_effort_no_args() {
+    match parse_command("/effort") {
+        Some(SlashCommand::Effort(level)) => assert_eq!(level, ""),
+        _ => panic!("expected Effort variant with empty string"),
+    }
+}
+
+#[test]
+fn parse_effort_with_level() {
+    match parse_command("/effort high") {
+        Some(SlashCommand::Effort(level)) => assert_eq!(level, "high"),
+        _ => panic!("expected Effort variant"),
+    }
+}
+
+#[test]
+fn parse_effort_max() {
+    match parse_command("/effort max") {
+        Some(SlashCommand::Effort(level)) => assert_eq!(level, "max"),
+        _ => panic!("expected Effort variant"),
+    }
+}

--- a/claude-rust-config/src/application/load_config.rs
+++ b/claude-rust-config/src/application/load_config.rs
@@ -96,4 +96,35 @@ mod tests {
         let merged = merge(global, project);
         assert_eq!(merged.model, Some("project-model".into()));
     }
+
+    #[test]
+    fn test_merge_effort_project_overrides_global() {
+        let global = Settings {
+            effort: Some("medium".into()),
+            ..Default::default()
+        };
+        let project = Settings {
+            effort: Some("high".into()),
+            ..Default::default()
+        };
+        let merged = merge(global, project);
+        assert_eq!(merged.effort, Some("high".into()));
+    }
+
+    #[test]
+    fn test_merge_effort_falls_back_to_global() {
+        let global = Settings {
+            effort: Some("low".into()),
+            ..Default::default()
+        };
+        let project = Settings::default();
+        let merged = merge(global, project);
+        assert_eq!(merged.effort, Some("low".into()));
+    }
+
+    #[test]
+    fn test_merge_effort_none_when_both_unset() {
+        let merged = merge(Settings::default(), Settings::default());
+        assert_eq!(merged.effort, None);
+    }
 }

--- a/claude-rust-config/src/application/load_config.rs
+++ b/claude-rust-config/src/application/load_config.rs
@@ -50,6 +50,7 @@ fn merge(global: Settings, project: Settings) -> Settings {
         hooks: crate::domain::config::HooksConfig { pre_tool_use, post_tool_use, stop, session_start },
         max_turns: project.max_turns.or(global.max_turns),
         max_tokens: project.max_tokens.or(global.max_tokens),
+        effort: project.effort.or(global.effort),
     }
 }
 

--- a/claude-rust-config/src/domain/config.rs
+++ b/claude-rust-config/src/domain/config.rs
@@ -12,6 +12,8 @@ pub struct Settings {
     pub max_turns: Option<usize>,
     #[serde(default)]
     pub max_tokens: Option<u32>,
+    #[serde(default)]
+    pub effort: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/claude-rust-provider/src/infrastructure/anthropic_provider.rs
+++ b/claude-rust-provider/src/infrastructure/anthropic_provider.rs
@@ -41,6 +41,7 @@ const OPUS_MODEL: &str = "claude-opus-4-6";
 pub(crate) const MAX_TOKENS: u32 = 4096;
 
 pub(crate) const OAUTH_BETA_HEADER: &str = "oauth-2025-04-20,interleaved-thinking-2025-05-14,claude-code-20250219,prompt-caching-2024-07-31";
+pub(crate) const EFFORT_BETA_HEADER: &str = "effort-2025-11-24";
 pub(crate) const BILLING_HEADER_LINE: &str = "x-anthropic-billing-header: cc_version=2.1.87.d34; cc_entrypoint=cli;";
 
 pub struct AnthropicProvider {
@@ -50,6 +51,8 @@ pub struct AnthropicProvider {
     mode: Arc<AtomicU8>,
     thinking: Arc<AtomicBool>,
     max_tokens: AtomicU32,
+    thinking_budget: std::sync::Mutex<Option<u32>>,
+    effort: std::sync::Mutex<Option<String>>,
 }
 
 impl AnthropicProvider {
@@ -67,6 +70,8 @@ impl AnthropicProvider {
             mode,
             thinking: Arc::new(AtomicBool::new(false)), // off by default; enable with /think
             max_tokens: AtomicU32::new(MAX_TOKENS),
+            thinking_budget: std::sync::Mutex::new(None),
+            effort: std::sync::Mutex::new(None),
         }
     }
 
@@ -78,6 +83,24 @@ impl AnthropicProvider {
 
     pub fn set_max_tokens(&self, n: u32) {
         self.max_tokens.store(n, Ordering::Relaxed);
+    }
+
+    pub fn set_thinking_budget(&self, budget: u32) {
+        self.thinking.store(true, Ordering::Relaxed);
+        *self.thinking_budget.lock().unwrap() = Some(budget);
+    }
+
+    pub fn set_effort(&self, effort: &str) {
+        self.thinking.store(true, Ordering::Relaxed);
+        *self.effort.lock().unwrap() = Some(effort.to_string());
+    }
+
+    pub fn get_effort(&self) -> Option<String> {
+        self.effort.lock().ok().and_then(|g| g.clone())
+    }
+
+    pub fn clear_effort(&self) {
+        *self.effort.lock().unwrap() = None;
     }
 
     pub fn model_name(&self) -> String {
@@ -162,18 +185,26 @@ impl Provider for AnthropicProvider {
         let model_display = self.effective_model();
         let thinking = self.thinking.load(Ordering::Relaxed);
         let max_tokens = self.max_tokens.load(Ordering::Relaxed);
-        let body = build_request_body(&self.credential, &model_display, conversation, tools, thinking, max_tokens);
+        let thinking_budget = *self.thinking_budget.lock().unwrap();
+        let effort = self.effort.lock().unwrap().clone();
+        let body = build_request_body(&self.credential, &model_display, conversation, tools, thinking, max_tokens, thinking_budget, effort.as_deref());
 
         let request = match &self.credential {
             Credential::ClaudeCodeOAuth { access_token, .. } => {
                 let url = format!("{base_url}/v1/messages?beta=true");
                 tracing::debug!(model = %model_display, url = %url, "sending OAuth request");
 
+                let mut beta = OAUTH_BETA_HEADER.to_string();
+                if effort.is_some() {
+                    beta.push(',');
+                    beta.push_str(EFFORT_BETA_HEADER);
+                }
+
                 self.client
                     .post(&url)
                     .header("Authorization", format!("Bearer {access_token}"))
                     .header("anthropic-version", "2023-06-01")
-                    .header("anthropic-beta", OAUTH_BETA_HEADER)
+                    .header("anthropic-beta", beta)
                     .header("anthropic-dangerous-direct-browser-access", "true")
                     .header("User-Agent", "claude-cli/2.1.87 (external, cli)")
                     .header("x-app", "cli")
@@ -190,11 +221,15 @@ impl Provider for AnthropicProvider {
                     .header("anthropic-version", "2023-06-01")
                     .header("content-type", "application/json");
 
-                let beta = if thinking {
-                    "prompt-caching-2024-07-31,interleaved-thinking-2025-05-14"
+                let mut beta = if thinking {
+                    "prompt-caching-2024-07-31,interleaved-thinking-2025-05-14".to_string()
                 } else {
-                    "prompt-caching-2024-07-31"
+                    "prompt-caching-2024-07-31".to_string()
                 };
+                if effort.is_some() {
+                    beta.push(',');
+                    beta.push_str(EFFORT_BETA_HEADER);
+                }
                 rb = rb.header("anthropic-beta", beta);
                 rb
             }

--- a/claude-rust-provider/src/infrastructure/request_builder.rs
+++ b/claude-rust-provider/src/infrastructure/request_builder.rs
@@ -11,6 +11,8 @@ pub fn build_request_body(
     tools: &[Value],
     thinking: bool,
     max_tokens: u32,
+    thinking_budget: Option<u32>,
+    effort: Option<&str>,
 ) -> Value {
     let total = conversation.messages.len();
     let messages: Vec<Value> = conversation.messages.iter().enumerate().map(|(mi, msg)| {
@@ -81,9 +83,32 @@ pub fn build_request_body(
     }
 
     if thinking {
-        let budget = 5000u32;
-        if max_tokens <= budget { body["max_tokens"] = json!(budget + 4096); }
-        body["thinking"] = json!({"type": "enabled", "budget_tokens": budget});
+        let model_lower = model.to_lowercase();
+        let supports_adaptive = model_lower.contains("opus-4-6") || model_lower.contains("sonnet-4-6");
+
+        if supports_adaptive {
+            // Models that support adaptive thinking: let the model decide how much to think
+            body["thinking"] = json!({"type": "adaptive"});
+        } else {
+            match thinking_budget {
+                Some(budget) => {
+                    let effective_max = max_tokens.max(budget + 16384);
+                    body["max_tokens"] = json!(effective_max);
+                    let effective_budget = budget.min(effective_max - 1);
+                    body["thinking"] = json!({"type": "enabled", "budget_tokens": effective_budget});
+                }
+                None => {
+                    let budget = 5000u32;
+                    if max_tokens <= budget { body["max_tokens"] = json!(budget + 4096); }
+                    body["thinking"] = json!({"type": "enabled", "budget_tokens": budget});
+                }
+            }
+        }
+    }
+
+    // Effort level (max/high/medium/low)
+    if let Some(eff) = effort {
+        body["output_config"] = json!({"effort": eff});
     }
 
     if !tools.is_empty() {

--- a/claude-rust-provider/src/infrastructure/request_builder.rs
+++ b/claude-rust-provider/src/infrastructure/request_builder.rs
@@ -122,6 +122,109 @@ pub fn build_request_body(
     body
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claude_rust_types::{Conversation, Message, ContentBlock, Role};
+
+    fn api_key_credential() -> Credential {
+        Credential::ApiKey {
+            api_key: "test-key".into(),
+            base_url: "https://api.anthropic.com".into(),
+        }
+    }
+
+    fn simple_conversation() -> Conversation {
+        Conversation {
+            system: Some("You are helpful.".into()),
+            messages: vec![Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text { text: "hello".into() }],
+            }],
+        }
+    }
+
+    #[test]
+    fn test_effort_sets_output_config() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-sonnet-4-6", &simple_conversation(),
+            &[], false, 4096, None, Some("high"),
+        );
+        assert_eq!(body["output_config"]["effort"], "high");
+    }
+
+    #[test]
+    fn test_effort_max_sets_output_config() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-opus-4-6", &simple_conversation(),
+            &[], true, 64000, None, Some("max"),
+        );
+        assert_eq!(body["output_config"]["effort"], "max");
+        // Adaptive thinking should also be present
+        assert_eq!(body["thinking"]["type"], "adaptive");
+    }
+
+    #[test]
+    fn test_no_effort_omits_output_config() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-sonnet-4-6", &simple_conversation(),
+            &[], false, 4096, None, None,
+        );
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn test_adaptive_thinking_for_opus() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-opus-4-6", &simple_conversation(),
+            &[], true, 16000, None, None,
+        );
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert!(body["thinking"].get("budget_tokens").is_none());
+    }
+
+    #[test]
+    fn test_adaptive_thinking_for_sonnet_4_6() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-sonnet-4-6", &simple_conversation(),
+            &[], true, 16000, None, None,
+        );
+        assert_eq!(body["thinking"]["type"], "adaptive");
+    }
+
+    #[test]
+    fn test_budget_thinking_for_older_model() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-haiku-4-5-20251001", &simple_conversation(),
+            &[], true, 16000, None, None,
+        );
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 5000);
+    }
+
+    #[test]
+    fn test_custom_thinking_budget() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-haiku-4-5-20251001", &simple_conversation(),
+            &[], true, 4096, Some(10000), None,
+        );
+        assert_eq!(body["thinking"]["type"], "enabled");
+        // effective_max = max(4096, 10000+16384) = 26384
+        // effective_budget = min(10000, 26384-1) = 10000
+        assert_eq!(body["thinking"]["budget_tokens"], 10000);
+        assert_eq!(body["max_tokens"], 26384);
+    }
+
+    #[test]
+    fn test_thinking_disabled_no_thinking_block() {
+        let body = build_request_body(
+            &api_key_credential(), "claude-opus-4-6", &simple_conversation(),
+            &[], false, 4096, None, None,
+        );
+        assert!(body.get("thinking").is_none());
+    }
+}
+
 fn sanitize_messages(mut messages: Vec<Value>) -> Vec<Value> {
     let mut i = 0;
     while i < messages.len() {

--- a/claude-rust/src/infrastructure/cli.rs
+++ b/claude-rust/src/infrastructure/cli.rs
@@ -29,6 +29,12 @@ pub struct Cli {
 
     #[arg(long, help = "Enable verbose logging")]
     pub verbose: bool,
+
+    #[arg(long, help = "Thinking budget tokens (also sets max_tokens, thinking uses max_tokens - 16384)")]
+    pub thinking_budget: Option<u32>,
+
+    #[arg(long, help = "Effort level: max, high, medium, low (enables thinking + effort)")]
+    pub effort: Option<String>,
 }
 
 impl Cli {

--- a/claude-rust/src/infrastructure/command_extras.rs
+++ b/claude-rust/src/infrastructure/command_extras.rs
@@ -140,18 +140,28 @@ pub fn handle_model_cmd(name: &str, provider: &AnthropicProvider, mode_flag: &st
     }
 }
 
-pub fn handle_effort_cmd(level: &str) -> CommandAction {
+pub fn handle_effort_cmd(level: &str, provider: &AnthropicProvider) -> CommandAction {
     if level.is_empty() {
+        let current = provider.get_effort().unwrap_or_else(|| "auto".to_string());
         return CommandAction::Output(format!(
-            "\n  {BOLD}{CYAN}Effort Levels{RESET}\n\n\
+            "\n  {BOLD}{CYAN}Effort Levels{RESET}  {DIM}(current: {current}){RESET}\n\n\
              {DIM}  low{RESET}     Quick, concise responses\n\
              {DIM}  medium{RESET}  Balanced (default)\n\
              {DIM}  high{RESET}    Thorough, detailed responses\n\
-             {DIM}  max{RESET}     Maximum depth and analysis\n"
+             {DIM}  max{RESET}     Maximum depth and analysis\n\
+             {DIM}  auto{RESET}    Clear effort override\n"
         ));
     }
+    if level == "auto" {
+        provider.clear_effort();
+        return CommandAction::Output(format!("\n  {DIM}Effort → auto (cleared){RESET}\n"));
+    }
     if !["low", "medium", "high", "max"].contains(&level) {
-        return CommandAction::Output(format!("\n  {DIM}Invalid effort level. Use: low, medium, high, max{RESET}\n"));
+        return CommandAction::Output(format!("\n  {DIM}Invalid effort level. Use: low, medium, high, max, auto{RESET}\n"));
+    }
+    provider.set_effort(level);
+    if level == "max" {
+        provider.set_max_tokens(64000);
     }
     CommandAction::Output(format!("\n  {DIM}Effort →{RESET} {BOLD}{CYAN}{level}{RESET}\n"))
 }

--- a/claude-rust/src/infrastructure/command_handler.rs
+++ b/claude-rust/src/infrastructure/command_handler.rs
@@ -94,7 +94,7 @@ pub async fn handle_slash_command(
 
     if matches!(cmd, SlashCommand::Usage) { return Some(CommandAction::Output(render_usage(provider).await)); }
 
-    if let SlashCommand::Effort(ref level) = cmd { return Some(handle_effort_cmd(level)); }
+    if let SlashCommand::Effort(ref level) = cmd { return Some(handle_effort_cmd(level, provider)); }
 
     if matches!(cmd, SlashCommand::Plan) {
         let current = PermissionMode::load(mode_flag);

--- a/claude-rust/src/main.rs
+++ b/claude-rust/src/main.rs
@@ -51,6 +51,25 @@ async fn main() {
     else if let Some(ref model) = config.model { provider.set_model(model); }
     if let Ok(model) = std::env::var("MODEL") { provider.set_model(&model); }
     if let Some(mt) = config.max_tokens { provider.set_max_tokens(mt); }
+    if let Some(total) = cli.thinking_budget {
+        provider.set_max_tokens(total);
+        let budget = total.saturating_sub(16384);
+        provider.set_thinking_budget(budget);
+    }
+
+    // Effort: env > CLI > settings
+    let effort_value = std::env::var("CLAUDE_CODE_EFFORT_LEVEL").ok()
+        .or_else(|| cli.effort.clone())
+        .or_else(|| config.effort.clone());
+    if let Some(ref effort) = effort_value {
+        let level = effort.to_lowercase();
+        if ["low", "medium", "high", "max"].contains(&level.as_str()) {
+            provider.set_effort(&level);
+            if level == "max" && cli.thinking_budget.is_none() {
+                provider.set_max_tokens(64000);
+            }
+        }
+    }
 
     let pause_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
 


### PR DESCRIPTION
## Summary

The `/effort` slash command existed but was display-only — it showed a message without actually changing the effort level sent to the API. This PR makes it functional end-to-end.

**What's new:**
- `/effort <level>` now calls `provider.set_effort()` so the selected level actually takes effect in API requests
- Effort is sent via `output_config.effort` with the `effort-2025-11-24` beta header (both OAuth and API key paths)
- `--effort` and `--thinking-budget` CLI flags for non-interactive usage
- `CLAUDE_CODE_EFFORT_LEVEL` environment variable support (precedence: env > CLI > settings)
- Effort level persisted in `settings.json` with global/project merge
- Adaptive thinking (`{"type": "adaptive"}`) for opus-4-6 and sonnet-4-6 models instead of the hardcoded 5000-token budget
- `/effort auto` to clear the effort override
- `/effort` with no args now shows the current effort level

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 16 tests pass, 0 failures
- [ ] Manual: `claude-rust --effort max -p "hello"` sends `output_config.effort: "max"` in the request
- [ ] Manual: `/effort high` in interactive mode changes subsequent API calls
- [ ] Manual: `CLAUDE_CODE_EFFORT_LEVEL=low claude-rust` overrides CLI and settings